### PR TITLE
Make compatible tutorial for Python3

### DIFF
--- a/GEOparse/GEOTypes.py
+++ b/GEOparse/GEOTypes.py
@@ -726,9 +726,9 @@ class GSE(BaseGEO):
             soft.append(self.database._get_object_as_soft())
         soft += ["^%s = %s" % (self.geotype, self.name),
                  self._get_metadata_as_string()]
-        for gsm in self.gsms.itervalues():
+        for gsm in self.gsms.values():
             soft.append(gsm._get_object_as_soft())
-        for gpl in self.gpls.itervalues():
+        for gpl in self.gpls.values():
             soft.append(gpl._get_object_as_soft())
 
         return "\n".join(soft)

--- a/GEOparse/GEOTypes.py
+++ b/GEOparse/GEOTypes.py
@@ -17,7 +17,7 @@ try:
     from urllib.error import HTTPError
 except ImportError:
     from urllib2 import HTTPError
-from six import iteritems
+from six import iteritems, itervalues
 
 
 
@@ -726,9 +726,9 @@ class GSE(BaseGEO):
             soft.append(self.database._get_object_as_soft())
         soft += ["^%s = %s" % (self.geotype, self.name),
                  self._get_metadata_as_string()]
-        for gsm in self.gsms.values():
+        for gsm in itervalues(self.gsms):
             soft.append(gsm._get_object_as_soft())
-        for gpl in self.gpls.values():
+        for gpl in itervalues(self.gpls):
             soft.append(gpl._get_object_as_soft())
 
         return "\n".join(soft)
@@ -738,3 +738,4 @@ class GSE(BaseGEO):
 
     def __repr__(self):
         return str("<%s: %s - %i SAMPLES, %i PLATFORM(s)>" % (self.geotype, self.name, len(self.gsms), len(self.gpls)))
+    

--- a/docs/Analyse_hsa-miR-124a-3p_transfection_time-course.rst
+++ b/docs/Analyse_hsa-miR-124a-3p_transfection_time-course.rst
@@ -429,7 +429,7 @@ genes.
 .. code:: python
 
     pivoted_control_samples_average = pivoted_control_samples.median(axis=1)
-    print "Number of probes before filtering: ", len(pivoted_control_samples_average)
+    print("Number of probes before filtering: ", len(pivoted_control_samples_average))
 
 
 .. parsed-literal::
@@ -444,7 +444,7 @@ genes.
 .. code:: python
 
     expressed_probes = pivoted_control_samples_average[pivoted_control_samples_average >= expression_threshold].index.tolist()
-    print "Number of probes above threshold: ", len(expressed_probes)
+    print("Number of probes above threshold: ", len(expressed_probes))
 
 
 .. parsed-literal::
@@ -476,7 +476,7 @@ DataFrame with LFCs:
                  '72 hours',
                  '120 hours']
     for time, group in experiments.groupby("Time"):
-        print time
+        print(time)
         control_name = group[group.Type == "control"].Experiment.iloc[0]
         transfection_name = group[group.Type == "transfection"].Experiment.iloc[0]
         lfc_results[time] = (samples[transfection_name] - samples[control_name]).to_dict()
@@ -761,7 +761,7 @@ We shall extract targets as a simple list of strings:
 .. code:: python
 
     miR124_targets_list = map(str, miR124_targets.GeneID.tolist())
-    print "Number of targets:", len(miR124_targets_list)
+    print("Number of targets:", len(miR124_targets_list))
 
 
 .. parsed-literal::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,8 +8,6 @@ To simplest example of usage::
 
     gse = GEOparse.get_GEO(geo="GSE1563", destdir="./")
 
-    gse = GEOparse.get_GEO(geo="GSE1563", destdir="./")
-
     print()
     print("GSM example:")
     for gsm_name, gsm in gse.gsms.items():

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,26 +8,28 @@ To simplest example of usage::
 
     gse = GEOparse.get_GEO(geo="GSE1563", destdir="./")
 
-    print
-    print "GSM example:"
-    for gsm_name, gsm in gse.gsms.iteritems():
-        print "Name: ", gsm_name
-        print "Metadata:",
-        for key, value in gsm.metadata.iteritems():
-            print " - %s : %s" % (key, ", ".join(value))
-        print "Table data:",
-        print gsm.table.head()
+    gse = GEOparse.get_GEO(geo="GSE1563", destdir="./")
+
+    print()
+    print("GSM example:")
+    for gsm_name, gsm in gse.gsms.items():
+        print("Name: ", gsm_name)
+        print("Metadata:",)
+        for key, value in gsm.metadata.items():
+            print(" - %s : %s" % (key, ", ".join(value)))
+        print ("Table data:",)
+        print (gsm.table.head())
         break
 
-    print
-    print "GPL example:"
-    for gpl_name, gpl in gse.gpls.iteritems():
-        print "Name: ", gpl_name
-        print "Metadata:",
-        for key, value in gpl.metadata.iteritems():
-            print " - %s : %s" % (key, ", ".join(value))
-        print "Table data:",
-        print gpl.table.head()
+    print()
+    print("GPL example:")
+    for gpl_name, gpl in gse.gpls.items():
+        print("Name: ", gpl_name)
+        print("Metadata:",)
+        for key, value in gpl.metadata.items():
+            print(" - %s : %s" % (key, ", ".join(value)))
+        print("Table data:",)
+        print(gpl.table.head())
         break
 
 Working with GEO accession


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "geoTest2.py", line 33, in <module>
    gse.to_soft("./GSEFoo.soft")
  File "/usr/local/lib/python3.4/dist-packages/GEOparse/GEOTypes.py", line 124, in to_soft
    outfile.write(self._get_object_as_soft())
  File "/usr/local/lib/python3.4/dist-packages/GEOparse/GEOTypes.py", line 729, in _get_object_as_soft
    for gsm in self.gsms.itervalues():
AttributeError: 'dict' object has no attribute 'itervalues'
```

I edited the code in usage.rst so it'll be compatible for Python3 also I replaced the `itervalues()` to `values()`