### PR TITLE
Add Timeout to urlopen Calls

### DIFF
--- a/GEOparse/utils.py
+++ b/GEOparse/utils.py
@@ -97,7 +97,7 @@ def download_from_url(url, destination_path, force=False, aspera=False,
                     fn = wgetter.download(url, outdir=os.path.dirname(
                         destination_path))
                 else:
-                    with closing(urlopen(url)) as r:
+                    with closing(urlopen(url, timeout=30)) as r:
                         with open(destination_path, mode='wb') as f:
                             copyfileobj(r, f)
             else:
@@ -113,7 +113,7 @@ def download_from_url(url, destination_path, force=False, aspera=False,
                     fn = wgetter.download(url, outdir=os.path.dirname(
                         destination_path))
                 else:
-                    with closing(urlopen(url)) as r:
+                    with closing(urlopen(url, timeout=30)) as r:
                         with open(destination_path, mode='wb') as f:
                             copyfileobj(r, f)
     except URLError:


### PR DESCRIPTION
This adds a `timeout` to `urlopen` calls.

This is significant for us, since we use GEOParse on such a large scale that these timeouts are a frequent problem.

The timeouts are only added in 'silent' mode, since the underlying `wgetter` [does not use timeouts where it should](https://github.com/phoemur/wgetter/blob/master/wgetter.py#L272).