### PR TITLE
Add partial arg to parse_GPL and get_GEO. #53

### DIFF
--- a/GEOparse/GEOparse.py
+++ b/GEOparse/GEOparse.py
@@ -425,7 +425,7 @@ def parse_GPL(filepath, entry_name=None, partial=None):
                         gses[entry_name] = GSE(name=entry_name,
                                                metadata=gse_metadata)
                     elif entry_type == "SAMPLE":
-                        if (partial) and (entry_name not in partial):
+                        if partial and entry_name not in partial:
                             continue
                         is_data, data_group = next(groupper)
                         gsms[entry_name] = parse_GSM(data_group, entry_name)

--- a/GEOparse/GEOparse.py
+++ b/GEOparse/GEOparse.py
@@ -54,8 +54,10 @@ def get_GEO(geo=None, filepath=None, destdir="./", how='full',
         aspera (:obj:`bool`, optional): EXPERIMENTAL Download using Aspera
             Connect. Follow Aspera instructions for further details. Defaults
             to False.
-        partial (:obj:'iterable', optional): Accession ID of GSM that you want
-            to parse partially from the GPL.
+        partial (:obj:'iterable', optional): A list of accession IDs of GSMs
+            to be partially extracted from GPL, works only if a file/accession
+            is a GPL.
+
 
     Returns:
         :obj:`GEOparse.BaseGEO`: A GEO object of given type.
@@ -398,8 +400,9 @@ def parse_GPL(filepath, entry_name=None, partial=None):
             or list of lines representing GPL from GSE file.
         entry_name (:obj:`str`, optional): Name of the entry. By default it is
             inferred from the data.
-        partial (:obj:'iterable', optional): Accession ID of GSM that you want
-            to parse partially from the GPL.
+        partial (:obj:'iterable', optional): A list of accession IDs of GSMs
+            to be partially extracted from GPL, works only if a file/accession
+            is a GPL.
 
     Returns:
         :obj:`GEOparse.GPL`: A GPL object.

--- a/GEOparse/GEOparse.py
+++ b/GEOparse/GEOparse.py
@@ -30,7 +30,7 @@ class NoEntriesException(Exception):
 
 def get_GEO(geo=None, filepath=None, destdir="./", how='full',
             annotate_gpl=False, geotype=None, include_data=False, silent=False,
-            aspera=False):
+            aspera=False, partial=None):
     """Get the GEO entry.
 
     The GEO entry is taken directly from the GEO database or read it from SOFT
@@ -54,6 +54,8 @@ def get_GEO(geo=None, filepath=None, destdir="./", how='full',
         aspera (:obj:`bool`, optional): EXPERIMENTAL Download using Aspera
             Connect. Follow Aspera instructions for further details. Defaults
             to False.
+        partial (:obj:'iterable', optional): Accession ID of GSM that you want
+            to parse partially from the GPL.
 
     Returns:
         :obj:`GEOparse.BaseGEO`: A GEO object of given type.
@@ -83,7 +85,7 @@ def get_GEO(geo=None, filepath=None, destdir="./", how='full',
     elif geotype.upper() == "GSE":
         return parse_GSE(filepath)
     elif geotype.upper() == 'GPL':
-        return parse_GPL(filepath)
+        return parse_GPL(filepath, partial=partial)
     elif geotype.upper() == 'GDS':
         return parse_GDS(filepath)
     else:
@@ -388,7 +390,7 @@ def parse_GSM(filepath, entry_name=None):
     return gsm
 
 
-def parse_GPL(filepath, entry_name=None):
+def parse_GPL(filepath, entry_name=None, partial=None):
     """Parse GPL entry from SOFT file.
 
     Args:
@@ -396,6 +398,8 @@ def parse_GPL(filepath, entry_name=None):
             or list of lines representing GPL from GSE file.
         entry_name (:obj:`str`, optional): Name of the entry. By default it is
             inferred from the data.
+        partial (:obj:'iterable', optional): Accession ID of GSM that you want
+            to parse partially from the GPL.
 
     Returns:
         :obj:`GEOparse.GPL`: A GPL object.
@@ -421,6 +425,8 @@ def parse_GPL(filepath, entry_name=None):
                         gses[entry_name] = GSE(name=entry_name,
                                                metadata=gse_metadata)
                     elif entry_type == "SAMPLE":
+                        if (partial) and (entry_name not in partial):
+                            continue
                         is_data, data_group = next(groupper)
                         gsms[entry_name] = parse_GSM(data_group, entry_name)
                     elif entry_type == "DATABASE":

--- a/tests/test_GEOparse.py
+++ b/tests/test_GEOparse.py
@@ -330,6 +330,24 @@ class TestGPL(unittest.TestCase):
         self.assertEqual(6, len(gpl.gses["GSE68087"].gsms))
         self.assertEqual(2, len(gpl.gses["GSE67974"].gsms))
 
+    def test_get_geo_gpl_partially(self):
+        partial = [
+            "GSM1662787",
+            "GSM1662789",
+            "GSM1662791",
+            "GSM1859499"
+        ]
+
+        gpl = GEO.get_GEO(geo="GPL20082", destdir=download_geo,
+                          include_data=True, partial=partial)
+        self.assertTrue(isinstance(gpl, GPL))
+        self.assertEqual(gpl.get_accession(), "GPL20082")
+
+        for gsm in gpl.gsms:
+            self.assertTrue(gsm in partial)
+
+        self.assertEqual(4, len(gpl.gsms))
+
     def test_get_geo_and_data_with_annotations(self):
         gpl = GEO.get_GEO(geo="GPL96", destdir=download_geo, annotate_gpl=True)
         self.assertTrue(isinstance(gpl, GPL))


### PR DESCRIPTION
Issue #53 
Add a 'partial' argument to parse_GPL() and get_GEO() to parse GSMs
partially from large GPL file. This 'partial' argument is an iterable
object containing the GSM accession IDs that you want to parse
partially from the GPL.