### PR TITLE
Parallel fastq

### DIFF
--- a/GEOparse/sra_downloader.py
+++ b/GEOparse/sra_downloader.py
@@ -239,7 +239,7 @@ class SRADownloader(object):
                 for fqoption, fqvalue in iteritems(self.fastq_dump_options):
                     if fqvalue:
                         cmd += (" --%s %s" % (fqoption, fqvalue))
-                    else:
+                    elif fqvalue is None:
                         cmd += (" --%s" % fqoption)
                 logger.debug(cmd)
                 process = sp.Popen(cmd, stdout=sp.PIPE,

--- a/GEOparse/sra_downloader.py
+++ b/GEOparse/sra_downloader.py
@@ -65,6 +65,9 @@ class SRADownloader(object):
             * keep_sra - bool
                 keep SRA files after download. Removes SRA file only if the
                 selected file type is different than "sra", defaults to False
+            * threads - int
+                number of threads to use if parallel-fastq-dump is used,
+                defaults to 4
             * fastq_dump_options - dict
                 pass options to fastq-dump (if used, the options has to be in
                 long form eg. --split-files), defaults to::
@@ -101,6 +104,7 @@ class SRADownloader(object):
         self.keep_sra = kwargs.get('keep_sra', False)
         self.silent = kwargs.get('silent', False)
         self.force = kwargs.get('force', False)
+        self.threads = kwargs.get('threads', 4)
 
         self.fastq_dump_options = {
             'split-files': None,
@@ -223,13 +227,20 @@ class SRADownloader(object):
                 if self.filetype == "fasta":
                     ftype = " --fasta "
                 cmd = "fastq-dump"
+                if utils.which('parallel-fastq-dump') is None:
+                    cmd += " %s --outdir %s %s"
+                else:
+                    logger.debug("Using parallel fastq-dump")
+                    cmd = " parallel-fastq-dump --threads %s"
+                    cmd = cmd % self.threads
+                    cmd += " %s --outdir %s -s %s"
+                cmd = cmd % (ftype, self.directory, filepath)
+
                 for fqoption, fqvalue in iteritems(self.fastq_dump_options):
                     if fqvalue:
                         cmd += (" --%s %s" % (fqoption, fqvalue))
                     else:
                         cmd += (" --%s" % fqoption)
-                cmd += " %s --outdir %s %s"
-                cmd = cmd % (ftype, self.directory, filepath)
                 logger.debug(cmd)
                 process = sp.Popen(cmd, stdout=sp.PIPE,
                                    stderr=sp.PIPE,

--- a/scripts/gsm2fastq
+++ b/scripts/gsm2fastq
@@ -48,6 +48,6 @@ if __name__ == "__main__":
             args.email,
             directory=args.outdir,
             filetype=args.filetype,
-            aspera=os.environ.has_key("ASPERA_HOME"),
+            aspera="ASPERA_HOME" in os.environ,
             )
-    print "Supp_{}_{}".format(gsm.name, title)
+    print("Supp_{}_{}".format(gsm.name, title))


### PR DESCRIPTION
Hi @guma44 , just a few minor additions:

* Support for https://github.com/rvalieris/parallel-fastq-dump. The way it works is that SRA download now automatically uses parallel-fastq-dump if it's in the path. 
* I've added a minor change [here](https://github.com/simonvh/GEOparse/blob/a18edc80476266e66479e78a66e5350459efc71c/GEOparse/sra_downloader.py#L242). This does not change default behavior, however, it does allow to switch default options off by setting the value to `False`. There might be a better way, feel free to comment.