### PR TITLE
Fixes typo in documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,7 +60,7 @@ specifying path to the file::
 
 This will read the file into GSE object.
 
-Crating and saving SOFT file
+Creating and saving SOFT file
 ----------------------------
 
 When doing own experiments one might want to submit the data to the GEO. In this case, one shuld


### PR DESCRIPTION
Was reading the docs and noticed a small typo in one of the headers.

No new or changed functionality, so no tests included.