### PR TITLE
Declare total_size outside of try block so it can't be undeclared.

### DIFF
--- a/src/GEOparse/downloader.py
+++ b/src/GEOparse/downloader.py
@@ -142,13 +142,14 @@ class Downloader(object):
         return filename
 
     def _download_ftp(self, silent=False):
+        total_size = 0
         parsed_url = urlparse(self.url)
         try:
             ftp = FTP(parsed_url.netloc)
             ftp.login()
-            total_size = ftp.size(parsed_url.path)
-            if total_size is None:
-                total_size = 0
+            ftp_size = ftp.size(parsed_url.path)
+            if ftp_size is None:
+                total_size = ftp_size
             wrote = list()  # cannot add in the callback, has to be a list
             with open(self._temp_file_name, "wb") as f:
                 if silent:

--- a/src/GEOparse/downloader.py
+++ b/src/GEOparse/downloader.py
@@ -148,7 +148,7 @@ class Downloader(object):
             ftp = FTP(parsed_url.netloc)
             ftp.login()
             ftp_size = ftp.size(parsed_url.path)
-            if ftp_size is None:
+            if ftp_size is not None:
                 total_size = ftp_size
             wrote = list()  # cannot add in the callback, has to be a list
             with open(self._temp_file_name, "wb") as f:


### PR DESCRIPTION
While using GEOparse I got the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/GEOparse/utils.py", line 80, in download_from_url
    fn.download(silent=silent, force=force)
  File "/usr/local/lib/python3.6/dist-packages/GEOparse/downloader.py", line 82, in download
    _download()
  File "/usr/local/lib/python3.6/dist-packages/GEOparse/downloader.py", line 53, in _download
    self._download_ftp(silent=silent)
  File "/usr/local/lib/python3.6/dist-packages/GEOparse/downloader.py", line 187, in _download_ftp
    if total_size != 0:
UnboundLocalError: local variable 'total_size' referenced before assignment

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/data_refinery_foreman/surveyor/external_source.py", line 171, in survey
    experiment, samples = self.discover_experiment_and_samples()
  File "/home/user/data_refinery_foreman/surveyor/geo.py", line 500, in discover_experiment_and_samples
    experiment, samples = self.create_experiment_and_samples_from_api(experiment_accession_code)
  File "/home/user/data_refinery_foreman/surveyor/geo.py", line 246, in create_experiment_and_samples_from_api
    gse = GEOparse.get_GEO(experiment_accession_code, destdir=self.get_temp_path(), silent=True)
  File "/usr/local/lib/python3.6/dist-packages/GEOparse/GEOparse.py", line 103, in get_GEO
    aspera=aspera,
  File "/usr/local/lib/python3.6/dist-packages/GEOparse/GEOparse.py", line 263, in get_GEO_file
    utils.download_from_url(url, filepath, silent=silent, aspera=aspera)
  File "/usr/local/lib/python3.6/dist-packages/GEOparse/utils.py", line 84, in download_from_url
    + "data might not be public yet."
OSError: Download failed due to 'local variable 'total_size' referenced before assignment'. ID could be incorrect or the data might not be public yet.
```

This PR should prevent a local variable being referenced before assignment.